### PR TITLE
AE-75 On afterexeccommand, return the focus to the focused toolbar on the button that was selected

### DIFF
--- a/src/ui/yui/src/adapter/yui.js
+++ b/src/ui/yui/src/adapter/yui.js
@@ -77,6 +77,8 @@ YUI.add('alloy-editor', function(Y) {
             editor.on('toolbarKey', this._onToolbarKey, this);
 
             editor.on('toolbarActive', this._onToolbarActive, this);
+
+            editor.on('afterCommandExec', this._returnFocusToToolbar, this);
         },
 
         /**
@@ -133,6 +135,8 @@ YUI.add('alloy-editor', function(Y) {
                 if (toolbar !== activeToolbar && toolbar.focus()) {
                     this._activeToolbar = toolbar;
 
+                    this._focusedToolbar = toolbar;
+
                     return true;
                 }
             }, this);
@@ -145,10 +149,12 @@ YUI.add('alloy-editor', function(Y) {
          * @method _focusVisibleToolbar
          * @protected
          */
-        _focusVisibleToolbar: function() {
+        _focusVisibleToolbar: function(currentButton) {
             Y.Object.some(this._editor.config.toolbars, function(toolbar) {
-                if (toolbar != this._activeToolbar && toolbar.focus()) {
+                if (toolbar != this._activeToolbar && toolbar.focus(currentButton)) {
                     this._activeToolbar = toolbar;
+
+                    this._focusedToolbar = toolbar;
 
                     return toolbar.get('visible');
                 }
@@ -251,8 +257,26 @@ YUI.add('alloy-editor', function(Y) {
             } else if (event.data.keyCode === KEY_ESC) {
                 this._activeToolbar.blur();
                 this._activeToolbar = null;
+                this._focusedToolbar = null;
 
                 this._hideToolbars();
+            }
+        },
+
+        /**
+         * Checks if a toolbar was focused by keyboard,
+         * and returns the focus to it.
+         *
+         * @method _returnFocusToToolbar
+         * @protected
+         */
+        _returnFocusToToolbar: function() {
+            var toolbar = this._focusedToolbar;
+
+            if (toolbar) {
+                var currentButton = toolbar.getActiveButton();
+
+                this._focusVisibleToolbar(currentButton);
             }
         },
 

--- a/src/ui/yui/src/toolbars/toolbar-base.js
+++ b/src/ui/yui/src/toolbars/toolbar-base.js
@@ -74,19 +74,28 @@ YUI.add('toolbar-base', function(Y) {
          * @method focus
          * @return {Boolean} True if toolbar has been focused, false otherwise.
          */
-        focus: function() {
+        focus: function(currentButton) {
             var buttonsContainer,
+                index,
                 visible;
 
             buttonsContainer = this.get('buttonsContainer');
 
+            index = currentButton || 0;
+
             visible = this.get('visible');
 
             if (visible) {
-                buttonsContainer.focusManager.focus(0);
+                buttonsContainer.focusManager.focus(index);
             }
 
             return visible;
+        },
+
+        getActiveButton: function() {
+            var buttonsContainer = this.get('buttonsContainer');
+
+            return buttonsContainer.focusManager.get('activeDescendant');
         },
 
         /**


### PR DESCRIPTION
Hi Iliyan, 

we found a bug in CKEDITOR with the "execCommand" function. This was always retrieving the focus to the editor, but if we access to the toolbar by keyboard, we don't want this. 

So here is a solution for retrieving the focus to the toolbar only if this was accesed by keyboard. 
